### PR TITLE
themes: link to directory

### DIFF
--- a/themes/nspcc-theme/layouts/partials/header.html
+++ b/themes/nspcc-theme/layouts/partials/header.html
@@ -21,15 +21,15 @@
             <li class=""><a href="#about" class="scrollLink" alt="About">{{ i18n "header_about" }}</a></li>
             <li class=""><a href="#team" class="scrollLink" alt="Team">{{ i18n "header_team" }}</a></li>
             <li class=""><a href="#roadmap" class="scrollLink" alt="Roadmap">{{ i18n "header_roadmap" }}</a></li>
-            <li class=""><a href="{{ absLangURL "publications" }}" class="" alt="Publications">{{ i18n "header_publications" }}</a></li>
-            <li class=""><a href="{{ absLangURL "jobs" }}" class="" alt="Jobs">{{ i18n "header_jobs" }}</a></li>
+            <li class=""><a href="{{ absLangURL "publications/" }}" class="" alt="Publications">{{ i18n "header_publications" }}</a></li>
+            <li class=""><a href="{{ absLangURL "jobs/" }}" class="" alt="Jobs">{{ i18n "header_jobs" }}</a></li>
             <li class=""><a href="#contacts" class="scrollLink" alt="Contacts">{{ i18n "header_contacts" }}</a></li>
           {{ else }}
             <li class=""><a href="{{ absLangURL "/" }}#about" alt="About">{{ i18n "header_about" }}</a></li>
             <li class=""><a href="{{ absLangURL "/" }}#team" alt="Team">{{ i18n "header_team" }}</a></li>
             <li class=""><a href="{{ absLangURL "/" }}#roadmap" alt="Roadmap">{{ i18n "header_roadmap" }}</a></li>
-            <li class=""><a href="{{ absLangURL "publications" }}" class="" alt="Publications">{{ i18n "header_publications" }}</a></li>
-            <li class=""><a href="{{ absLangURL "jobs" }}" class="" alt="Jobs">{{ i18n "header_jobs" }}</a></li>
+            <li class=""><a href="{{ absLangURL "publications/" }}" class="" alt="Publications">{{ i18n "header_publications" }}</a></li>
+            <li class=""><a href="{{ absLangURL "jobs/" }}" class="" alt="Jobs">{{ i18n "header_jobs" }}</a></li>
             <li class=""><a href="{{ absLangURL "/" }}#contacts" alt="Contacts">{{ i18n "header_contacts" }}</a></li>
           {{ end }}
         </ul>


### PR DESCRIPTION
Generated contents has these as directories, so an appropriate index.html should be served, but nginx that doesn't store all of the contents locally (serving from NeoFS or otherwise proxying) can't differentiate between file and directory access leading tot 404 error. This slash at the end allows to have different rewrite rules and serve everything correctly.